### PR TITLE
more options tweaking:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ADD config.yaml /app/
 ADD uwsgi.ini /app/
 ADD run.sh /app/
 ADD index.js /app/
+RUN ln -s /app/run.sh /usr/bin/zimit
 
-ENTRYPOINT ["/app/run.sh"]
+CMD ["zimit"]
 

--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ function runWarc2Zim(params, checkOnly = true) {
           break;
 
         case "object":
-          zimOptsStr += params[key].join(` --${key} `);
+          zimOptsStr += params[key].map(x => `"${x}"`).join(` --${key} `) + " ";
           break;
       }
     }

--- a/index.js
+++ b/index.js
@@ -325,8 +325,15 @@ function runWarc2Zim(params, checkOnly = true) {
     if (!OPTS.includes(key)) {
       zimOptsStr += (key.length === 1 ? "-" : "--") + key + " ";
 
-      if (typeof(params[key]) === "string") {
-        zimOptsStr += `"${params[key]}" `;
+      switch (typeof(params[key])) {
+        case "string":
+        case "number":
+          zimOptsStr += `"${params[key]}" `;
+          break;
+
+        case "object":
+          zimOptsStr += params[key].join(` --${key} `);
+          break;
       }
     }
   }


### PR DESCRIPTION
- correct parsing of repeated params, fixes #26, #18
- switch to 'zimit' CMD instead of ENTRYPOINT  (#21)

For testing:
```
docker run -it ... openzim/zimit zimit --name "test" --url https://example.com/ --tags some=tag --tags another=val -V
...
Running: warc2zim --name "test" --url "https://example.com/" --tags "some=tag" --tags "another=val" -V
```

