### PR TITLE
Enhanced --statsFilename support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: build image
-        run: docker build -t openzim/zimit:dev .
+        run: docker build -t zimit .
 
       - name: run crawl
-        run: docker run -v $PWD/output:/output openzim/zimit:dev zimit --url http://isago.ml/ --name isago --zim-file isago.zim --adminEmail test@example.com --mobileDevice --statsFilename /output/stats.json --keep
+        run: docker run -v $PWD/output:/output zimit zimit --url http://isago.ml/ --name isago --zim-file isago.zim --adminEmail test@example.com --mobileDevice --statsFilename /output/stats.json --keep
 
       - name: run integration test suite
-        run: docker run -v $PWD/test/integration.py:/app/integration.py -v $PWD/output:/output openzim/zimit:dev bash -c "pip install pytest; pytest -v ./integration.py"
+        run: docker run -v $PWD/test/integration.py:/app/integration.py -v $PWD/output:/output zimit bash -c "pip install pytest; pytest -v ./integration.py"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /output
 
 WORKDIR /app
 
-RUN pip install 'warc2zim>=1.3.2' 'requests>=2.24.0'
+RUN pip install 'warc2zim>=1.3.3' 'requests>=2.24.0' 'inotify==0.2.10'
 
 ADD zimit.py /app/
 

--- a/test/integration.py
+++ b/test/integration.py
@@ -45,9 +45,19 @@ def test_user_agent():
 
 
 def test_stats_output():
-    with open("/output/stats.json") as fh:
+    with open("/output/crawl.json") as fh:
         assert json.loads(fh.read()) == {
             "numCrawled": 5,
             "workersRunning": 0,
             "total": 5,
+        }
+    with open("/output/warc2zim.json") as fh:
+        assert json.loads(fh.read()) == {
+            "written": 7,
+            "total": 7,
+        }
+    with open("/output/stats.json") as fh:
+        assert json.loads(fh.read()) == {
+            "done": 7,
+            "total": 7,
         }


### PR DESCRIPTION
- `--statsFilename` to now represent overall zimit progress and not just crawling
- Exposing a simpler (`done`, `total`) json format for progress
- Live converting individual step's progres into this file
- using warc2zim 1.3.3 for its `--progress-file` support
- Currently arbitrarily assigning 90% to crawl and 10% to warc2zim