### PR TITLE
Update to latest version of browsertrix-crawler (0.1.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webrecorder/browsertrix-crawler:0.1.3
+FROM webrecorder/browsertrix-crawler:0.1.4
 
 RUN mkdir -p /output
 


### PR DESCRIPTION
to add autofetch support for srcset (and also stylesheets)
should fix (#63)