### PR TITLE
Update to new organization of warc2zim code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Changed
+
+- Adapt to new `warc2zim` code structure
+- Using `main` warc2zim ⚠️ change before releasing!
+
 ### Added
 
 - New `--build` parameter (optional) to specify the directory holding Browsertrix files ; if not set, `--output`

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     # python setup (in venv not to conflict with browsertrix)
     && python3 -m venv /app/zimit \
-    && /app/zimit/bin/python -m pip install --no-cache-dir 'requests==2.31.0' 'inotify==0.2.10' 'tld==0.13' 'warc2zim==1.5.4' \
+    && /app/zimit/bin/python -m pip install --no-cache-dir 'requests==2.31.0' 'inotify==0.2.10' 'tld==0.13' \
+    'git+https://github.com/openzim/warc2zim@main#egg_name=warc2zim' \
     # placeholder (default output location)
     && mkdir -p /output \
     # disable chrome upgrade

--- a/zimit.py
+++ b/zimit.py
@@ -25,7 +25,7 @@ import inotify
 import inotify.adapters
 import requests
 from tld import get_fld
-from warc2zim.main import warc2zim
+from warc2zim.main import main as warc2zim
 from zimscraperlib.uri import rebuild_uri
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"


### PR DESCRIPTION
Older `warc2zim` method is now named `main`.