### PR TITLE
Add support for --logging parameter of browsertrix crawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `--version` flag to display Zimit version
+- New `--logging` flag to adjust Browsertrix Crawler logging (#273)
 
 ### Changed
 

--- a/src/zimit/zimit.py
+++ b/src/zimit/zimit.py
@@ -353,6 +353,11 @@ def run(raw_args):
         version=f"Zimit {__version__}",
     )
 
+    parser.add_argument(
+        "--logging",
+        help="Crawler logging configuration",
+    )
+
     zimit_args, warc2zim_args = parser.parse_known_args(raw_args)
 
     # pass url and output to warc2zim also
@@ -560,6 +565,7 @@ def get_node_cmd_line(args):
         "healthCheckPort",
         "overwrite",
         "config",
+        "logging",
     ]:
         value = getattr(args, arg)
         if value is None or (isinstance(value, bool) and value is False):


### PR DESCRIPTION
Fix #273 

Nota: 
- we now have intentionally two distinct flags:
  - `--logging` for browsertrix crawler
  - `--verbose` for warc2zim
- this is targeting `zimit2` branch because there is no urgency to release this and I don't want to have again the same commit in two distinct branches

While this is obviously a tradeoff, having two parameters allow to make more verbose only the tool that interest us.