### PR TITLE
Upgrade browsertrix crawler and remove redirect handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using `warc2zim2` warc2zim ⚠️ change before releasing!
 - Build temporary `zimit2` Docker image for testing ⚠️ remove before releasing!
 - Adopt Python bootstrap conventions
+- Removed handling of redirects by zimit, they are handled by browsertrix crawler and detected properly by warc2zim
+- Upgrade to Python 3.12 + upgrade dependencies
 
 ## [1.6.3] - 2024-01-18
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webrecorder/browsertrix-crawler:0.12.4
+FROM webrecorder/browsertrix-crawler:1.0.0-beta.5
 LABEL org.opencontainers.image.source https://github.com/openzim/zimit
 
 # add deadsnakes ppa for Python 3.12 on Ubuntu Jammy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webrecorder/browsertrix-crawler:1.0.0-beta.5
+FROM webrecorder/browsertrix-crawler:1.0.0-beta.6
 LABEL org.opencontainers.image.source https://github.com/openzim/zimit
 
 # add deadsnakes ppa for Python 3.12 on Ubuntu Jammy

--- a/src/zimit/zimit.py
+++ b/src/zimit/zimit.py
@@ -391,7 +391,7 @@ def run(raw_args):
         user_agent += f" {zimit_args.adminEmail}"
 
     if url:
-        url = clean_url(url)
+        url = get_cleaned_url(url)
         warc2zim_args.append("--url")
         warc2zim_args.append(url)
 
@@ -507,7 +507,7 @@ def run(raw_args):
     return warc2zim(warc2zim_args)
 
 
-def clean_url(url: str):
+def get_cleaned_url(url: str):
     parsed_url = urllib.parse.urlparse(url)
 
     # remove explicit port in URI for default-for-scheme as browsers does it

--- a/tests-integration/integration.py
+++ b/tests-integration/integration.py
@@ -65,12 +65,12 @@ def test_stats_output():
         }
     with open("/output/warc2zim.json") as fh:
         assert json.loads(fh.read()) == {
-            "written": 8,
-            "total": 8,
+            "written": 7,
+            "total": 7,
         }
     with open("/output/stats.json") as fh:
         assert json.loads(fh.read()) == {
-            "done": 8,
-            "total": 8,
+            "done": 7,
+            "total": 7,
             "limit": {"max": 0, "hit": False},
         }


### PR DESCRIPTION
Fix #256
Fix #284 
Fix #166

This PR adopts browsertrix crawler ~~1.0.0-beta5~~ 1.0.0-beta.6.

Among other things, this release now handles nicely redirect (https://github.com/webrecorder/browsertrix-crawler/pull/476).

We hence have to remove the handling we've previously done on our side and caused issues (#256). We just keep the cleaning of the URL (remove default ports 443 and 80).

As a side-effect, this will also solve #166 since browsertrix crawler is already permissive in terms of SSL certificates issues. The only SSL issues which will continue to be blocked are the ones where the browser cannot establish at all the connection, like https://panzer-war.com/ were the browser has no cipher in common with the server

Redirect handling has been tested with https://metafilter.com:
```
docker run -v $PWD/output:/output:rw --name zimit2_test--rm local-zimit:zimit2 zimit --limit 10 --adminEmail="contact+zimfarm@kiwix.org" --description="Test" --lang="en" --name="metafilter.com_en_all" --output="/output" --publisher="openZIM" --scopeType="prefix" --statsFilename="/output/task_progress.json" --title="Metafilter" --url="https://metafilter.com:443" --verbose
```

Handling of insecure connection withhttps://www.moneyinstructor.com (which still fails without the simplification of check_url):
```
docker run -v $PWD/output:/output:rw --name zimit2_test --rm local-zimit:zimit2 zimit --limit 10 --adminEmail="contact+zimfarm@kiwix.org" --description="Test" --lang="en" --name="www.moneyinstructor.com_en_all" --output="/output" --publisher="openZIM" --scopeType="prefix" --statsFilename="/output/task_progress.json" --title="MoneyInstructor" --url="https://www.moneyinstructor.com/" --verbose
```

This PR should not be merged before https://github.com/openzim/warc2zim/pull/196
