### PR TITLE
 Upgrade to Python 3.12, upgrade Python dependencies and add hatch-openzim plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,15 @@ repos:
   -   id: trailing-whitespace
   -   id: end-of-file-fixer
 - repo: https://github.com/psf/black
-  rev: "23.12.1"
+  rev: "24.2.0"
   hooks:
   -   id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
+  rev: v0.3.0
   hooks:
   - id: ruff
 - repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.347
+  rev: v1.1.352
   hooks:
   - id: pyright
     name: pyright (system)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM webrecorder/browsertrix-crawler:0.12.4
 LABEL org.opencontainers.image.source https://github.com/openzim/zimit
 
+# add deadsnakes ppa for Python 3.12 on Ubuntu Jammy
+RUN add-apt-repository ppa:deadsnakes/ppa -y
+
 RUN apt-get update \
  && apt-get install -qqy --no-install-recommends \
       libmagic1 \
-      python3.11-venv \
+      python3.12-venv \
  && rm -rf /var/lib/apt/lists/* \
  # python setup (in venv not to conflict with browsertrix)
- && python3.11 -m venv /app/zimit \
+ && python3.12 -m venv /app/zimit \
  # placeholder (default output location)
  && mkdir -p /output \
  # disable chrome upgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,29 +1,22 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-openzim==0.2.0"]
 build-backend = "hatchling.build"
 
 [project]
 name = "zimit"
-authors = [
-  { name = "Kiwix", email = "dev@kiwix.org" },
-]
-keywords = ["some"]
 requires-python = ">=3.11,<3.12"
 description = "Make ZIM file from any website through crawling"
 readme = "README.md"
-license = {text = "GPL-3.0-or-later"}
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-]
 dependencies = [
   "requests==2.31.0",
   "inotify==0.2.10",
   "tld==0.13",
   "warc2zim @ git+https://github.com/openzim/warc2zim@warc2zim2",
 ]
-dynamic = ["version"]
+dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
+
+[tool.hatch.metadata.hooks.openzim-metadata]
+kind = "scraper"
 
 [tool.hatch.metadata]
 allow-direct-references = true  # to be removed once we use a released warc2zim version
@@ -51,10 +44,6 @@ dev = [
   "zimit[test]",
   "zimit[check]",
 ]
-
-[project.urls]
-Homepage = "https://github.com/openzim/zimit"
-Donate = "https://www.kiwix.org/en/support-us/"
 
 [project.scripts]
 zimit = "zimit:zimit.zimit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zimit"
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.12,<3.13"
 description = "Make ZIM file from any website through crawling"
 readme = "README.md"
 dependencies = [
@@ -94,10 +94,10 @@ all = "inv checkall --args '{args}'"
 
 [tool.black]
 line-length = 88
-target-version = ['py311']
+target-version = ['py312']
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 88
 src = ["src"]
 
@@ -220,5 +220,5 @@ exclude_lines = [
 include = ["src", "tests", "tasks.py"]
 exclude = [".env/**", ".venv/**"]
 extraPaths = ["src"]
-pythonVersion = "3.11"
+pythonVersion = "3.12"
 typeCheckingMode="basic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,19 +33,19 @@ scripts = [
   "invoke==2.2.0",
 ]
 lint = [
-  "black==23.12.1",
-  "ruff==0.1.3",
+  "black==24.2.0",
+  "ruff==0.3.0",
 ]
 check = [
-  "pyright==1.1.347",
+  "pyright==1.1.352",
 ]
 test = [
-  "pytest==7.4.4",
-  "coverage==7.4.0",
+  "pytest==8.0.2",
+  "coverage==7.4.3",
 ]
 dev = [
-  "pre-commit==3.6.0",
-  "debugpy==1.8.0",
+  "pre-commit==3.6.2",
+  "debugpy==1.8.1",
   "zimit[scripts]",
   "zimit[lint]",
   "zimit[test]",
@@ -111,6 +111,8 @@ target-version = ['py311']
 target-version = "py311"
 line-length = 88
 src = ["src"]
+
+[tool.ruff.lint]
 select = [
   "A",  # flake8-builtins
   # "ANN",  # flake8-annotations
@@ -187,17 +189,17 @@ unfixable = [
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["zimit"]
 
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 # add exceptions to B008 for fastapi.
 extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests**/**/*" = ["PLR2004", "S101", "TID252"]
 

--- a/tasks.py
+++ b/tasks.py
@@ -92,7 +92,7 @@ def fix_black(ctx: Context, args: str = "."):
 def fix_ruff(ctx: Context, args: str = "."):
     """fix all ruff rules"""
     args = args or "."  # needed for hatch script
-    ctx.run(f"ruff --fix {args}", pty=use_pty)
+    ctx.run(f"ruff check --fix {args}", pty=use_pty)
 
 
 @task(


### PR DESCRIPTION
Maintenance work:
- Upgrade to Python 3.12
  - since our Docker image is based on browsertrix-crawler ([Dockerfile](https://github.com/webrecorder/browsertrix-crawler/blob/main/Dockerfile)) which is based on browsertrix-browser-base ([Dockerfile](https://github.com/webrecorder/browsertrix-browser-base/blob/main/Dockerfile)) which is for now based on Ubuntu Jammy
  - since Ubuntu Jammy does not provides Python 3.12 apt packages
  - I had to add the deadsnakes PPA (which is a recommendable PPA team)
- Upgrade dependencies
  - ruff 0.3 has deprecated `ruff --fix` in favor of `ruff check --fix`
- Adopt hatch-openzim plugin for metadata handling