### PR TITLE
Fix `--waitUntil` crawler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix support for Youtube videos (#291)
+- Fix crawler `--waitUntil` values (#289)
 
 ## [1.6.3] - 2024-01-18
 

--- a/src/zimit/zimit.py
+++ b/src/zimit/zimit.py
@@ -5,7 +5,6 @@ and then calls the Node based driver
 """
 
 import atexit
-import itertools
 import json
 import logging
 import shutil
@@ -120,10 +119,6 @@ class ProgressFileWatcher:
 
 
 def run(raw_args):
-    wait_until_options = ["load", "domcontentloaded", "networkidle"]
-    wait_until_all = wait_until_options + [
-        f"{a},{b}" for a, b in itertools.combinations(wait_until_options, 2)
-    ]
     parser = ArgumentParser(
         description="Run a browser-based crawl on the specified URL and convert to ZIM"
     )
@@ -143,8 +138,8 @@ def run(raw_args):
     parser.add_argument(
         "--waitUntil",
         help="Puppeteer page.goto() condition to wait for before continuing. One of "
-        f"{wait_until_options} or a comma-separated combination of those.",
-        choices=wait_until_all,
+        "load, domcontentloaded, networkidle0 or networkidle2, or a "
+        "comma-separated combination of those.",
         default="load",
     )
 


### PR DESCRIPTION
Fix #289 

Fix documentation about --waitUntil allowed values and drop choices checks

Changes:
- in documentation (usage), add networkidle0, networkidle2 and drop networkidle to reflect crawler changes 
- drop choices check since this is anyway checked right at scraper start in crawler startup (this ensures to be more permissive should one want to use a different crawler version that the one supported in Docker image)