### PR TITLE
Strip user-agent whitespaces and ignore empty user agents

### DIFF
--- a/src/zimit/zimit.py
+++ b/src/zimit/zimit.py
@@ -558,6 +558,16 @@ def get_node_cmd_line(args):
         "logging",
     ]:
         value = getattr(args, arg)
+        if arg == "userAgent":
+            # - strip leading whitespace which are not allowed on some websites
+            # - strip trailing whitespace which are either not allowed if no suffix is
+            # used, or duplicate with the automatically added one if a suffix is there
+            # - value is None when userAgent is not passed
+            if value:
+                value = value.strip()
+            if not value:
+                # ignore empty userAgent arg and keep crawler default value if empty
+                continue
         if value is None or (isinstance(value, bool) and value is False):
             continue
         node_cmd.append("--" + arg)


### PR DESCRIPTION
Fix #281 

Rationale: 
- userAgent deserves a special handling to remove whitespaces:
  - leading are not allowed on some websites
  - trailing are useless especially when using in conjunction with a suffix which already adds a space
-  refuse empty userAgent which are bad:
  - no real reason to permit it
  - and it causes issues once combined with a userAgentSuffix which adds a leading space
- do not generalize to refuse empty CLI arg since it might be needed in some occasion where ones want to blank the crawler default value 