### PR TITLE
Add support for custom behaviors configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make it clear that `--profile` argument can be an HTTP(S) URL (and not only a path) (#288)
+- Add `--custom-behaviors` argument to support path/HTTP(S) URL custom behaviors to pass to the crawler (#313)
 
 ## [2.0.6] - 2024-08-02
 


### PR DESCRIPTION
Fix #313 

Changes:
- new `--custom-behaviors` CLI argument, comma separated list of custom behavior path or HTTP(S) url
- create a temp subfolder to host all these custom behavior since crawler `--customBehaviors` expects a folder
- either copy or download custom behaviors to this temp subfolder
- pass proper argument to crawler when custom behaviors have been configured