### PR TITLE
Add test checking that expected entries are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make it clear that `--profile` argument can be an HTTP(S) URL (and not only a path) (#288)
 - Add `--custom-behaviors` argument to support path/HTTP(S) URL custom behaviors to pass to the crawler (#313)
 - Fix README imprecisions + add back warc2zim availability in docker image (#314)
+- Enhance integration test to assert final content of the ZIM (#287)
 
 ## [2.0.6] - 2024-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--custom-behaviors` argument to support path/HTTP(S) URL custom behaviors to pass to the crawler (#313)
+
 ### Changed
 
 - Make it clear that `--profile` argument can be an HTTP(S) URL (and not only a path) (#288)
-- Add `--custom-behaviors` argument to support path/HTTP(S) URL custom behaviors to pass to the crawler (#313)
 - Fix README imprecisions + add back warc2zim availability in docker image (#314)
 - Enhance integration test to assert final content of the ZIM (#287)
 

--- a/tests-integration/integration.py
+++ b/tests-integration/integration.py
@@ -31,6 +31,24 @@ def test_zim_scraper():
     assert "Browsertrix crawler " in scraper
 
 
+def test_files_list():
+    """Check that expected files are present in the ZIM at proper path"""
+    zim_fh = Archive("/output/isago.zim")
+    for expected_entry in [
+        "_zim_static/__wb_module_decl.js",
+        "_zim_static/wombat.js",
+        "_zim_static/wombatSetup.js",
+        "isago.rskg.org/",
+        "isago.rskg.org/a-propos",
+        "isago.rskg.org/conseils",
+        "isago.rskg.org/faq",
+        "isago.rskg.org/static/favicon256.png",
+        "isago.rskg.org/static/tarifs-isago.pdf",
+        "maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css",
+    ]:
+        assert zim_fh.get_content(expected_entry)
+
+
 def test_user_agent():
     """Test that mobile user agent was used
 


### PR DESCRIPTION
Fix #287 

Changes:
- assert that expect ZIM entries are present in the final ZIM of the integration tests