### PR TITLE
Add logic to skip Youtube test on-demand

### DIFF
--- a/.github/workflows/DailyTests.yaml
+++ b/.github/workflows/DailyTests.yaml
@@ -27,8 +27,8 @@ jobs:
           path: output/tests_eng_test-website.zim
           retention-days: 30
 
-      - name: build selenium test image
-        run: docker build -t local-selenium tests-daily
+      - name: build tests-daily Docker image
+        run: docker build -t local-tests-daily tests-daily
 
       - name: run integration test suite
-        run: docker run -v $PWD/tests-daily/daily.py:/app/daily.py -v $PWD/output:/output local-selenium bash -c "cd /app && pytest -h && pytest -v --log-level=INFO --log-format='%(levelname)s - %(message)s' daily.py"
+        run: docker run -e SKIP_YOUTUBE_TEST="True" -v $PWD/tests-daily/daily.py:/app/daily.py -v $PWD/output:/output local-tests-daily bash -c "cd /app && pytest -v --log-level=INFO --log-format='%(levelname)s - %(message)s' daily.py"

--- a/tests-daily/daily.py
+++ b/tests-daily/daily.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 from time import sleep
 
@@ -14,6 +15,8 @@ KIWIX_SERVE_START_SLEEP = 1
 
 ZIM_NAME = "tests_eng_test-website"
 YOUTUBE_VIDEO_PATH = "youtube.fuzzy.replayweb.page/embed/g5skcrNXdDM"
+
+SKIP_YOUTUBE_TEST = os.getenv("SKIP_YOUTUBE_TEST", "False").lower() == "true"
 
 CHECK_VIDEO_IS_PLAYING_AFTER_SECS = 30
 
@@ -79,6 +82,7 @@ def kiwix_serve():
     process.terminate()
 
 
+@pytest.mark.skipif(SKIP_YOUTUBE_TEST, reason="Youtube test disabled by environment")
 def test_youtube_video(chrome_driver, kiwix_serve):  # noqa: ARG001
     """Test that youtube video loads, and still plays after a while"""
 


### PR DESCRIPTION
Fix #398

Since Youtube test might be flaky due to environmental constraints, let's add an option to skip it.