### PR TITLE
Upgrade browsertrix-crawler to version 1.6.0 in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to browsertrix crawler 1.6.0 (#493)
+
 ## [3.0.4] - 2024-04-04
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM webrecorder/browsertrix-crawler:1.5.9
+FROM webrecorder/browsertrix-crawler:1.6.0
 LABEL org.opencontainers.image.source=https://github.com/openzim/zimit
 
 # add deadsnakes ppa for latest Python on Ubuntu


### PR DESCRIPTION
Fixes critical regression with ioredis: https://github.com/webrecorder/browsertrix-crawler/releases/tag/v1.6.0